### PR TITLE
Custom keyword when adding new options

### DIFF
--- a/dist/js/standalone/selectize.js
+++ b/dist/js/standalone/selectize.js
@@ -1423,7 +1423,7 @@
 			var self = this;
 			var field_label = self.settings.labelField;
 			var field_optgroup = self.settings.optgroupLabelField;
-	
+			var field_createName = self.settings.createNameField;
 			var templates = {
 				'optgroup': function(data) {
 					return '<div class="optgroup">' + data.html + '</div>';
@@ -1438,7 +1438,7 @@
 					return '<div class="item">' + escape(data[field_label]) + '</div>';
 				},
 				'option_create': function(data, escape) {
-					return '<div class="create">Add <strong>' + escape(data.input) + '</strong>&hellip;</div>';
+					return '<div class="create">'+ field_createName +'<strong>' + escape(data.input) + '</strong>&hellip;</div>';
 				}
 			};
 	
@@ -3360,6 +3360,7 @@
 		labelField: 'text',
 		disabledField: 'disabled',
 		optgroupLabelField: 'label',
+		createNameField: 'Add ',	// Pre text when creating a new item for dropdown box
 		optgroupValueField: 'value',
 		lockOptgroupOrder: false,
 	


### PR DESCRIPTION
Allow custom keyword to be used instead of default "Add" when selecting an option that is not in the selectize dropdown.

**Before**

![Screenshot from 2020-02-11 19-12-42](https://user-images.githubusercontent.com/48839591/74241766-b29b0a80-4d02-11ea-897f-d31e0cf9cf64.png)

**After**

![Screenshot from 2020-02-11 19-14-23](https://user-images.githubusercontent.com/48839591/74241826-cd6d7f00-4d02-11ea-9c2f-47a311034dea.png)